### PR TITLE
Update Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "aldrichtr"
+    labels:
+      - 'flag.dependencies'
+      - 'area.ci-cd'


### PR DESCRIPTION
Updated the Dependabot configuration to use GitHub Actions as the package ecosystem, changed the update schedule to monthly, and added assignees and labels.